### PR TITLE
Compatibility ggplot2 3.6.0

### DIFF
--- a/vignettes/d_other_sens.Rmd
+++ b/vignettes/d_other_sens.Rmd
@@ -164,7 +164,7 @@ ggplot(dat2, aes(x = RR_CD, y = bias_perc, group = COX2, colour = COX2)) +
     ggtitle(expression(paste("Bias as a function of misspecification of the ", RR[CD], " from the literature"))) +
     theme(legend.position = c(.85, .3),
           legend.title = element_blank()) +
-    annotate("text", label = expression(paste("Literature estimate ", RR[CD], " = 0.7")), x = 0.6, y = -3.75)
+    annotate("text", label = 'paste("Literature estimate ", RR[CD], " = 0.7")', x = 0.6, y = -3.75, parse = TRUE)
 ```
 
 ## Unmeasured Confounding and E-value


### PR DESCRIPTION
Hi there,

Apologies for not posting an issue first.
The ggplot2 package is planning an update for around May 2025 and a reverse dependency test identified a problem with the episensr package.
The details are explained in https://github.com/tidyverse/ggplot2/issues/6294, but essentially ggplot2 doesn't accept expressions as labels and we're becoming more strict about this.
This PR changes a single label to no longer be an expression.
You can test the changes yourself with the development version of ggplot2 (`pak::pak("tidyverse/ggplot2")`)

Best,
Teun